### PR TITLE
[new-rule] Enforce the use of template literals

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ It is suggested to create separate `eslint.config.mjs` files for backend and for
   Placeholder for the next version (at the beginning of the line):
   ### **WORK IN PROGRESS**
 -->
+### **WORK IN PROGRESS**
+
+-   (@GermanBluefox) Enforce the use of template literals instead of string concatenation: "Hello, " + name + "!" => `Hello, ${name}!`
+
 ### 0.1.5 (2024-09-12)
 
 -   (@GermanBluefox) added ReactJS eslint config file

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -39,6 +39,9 @@ const generalRules = {
     'brace-style': 'error',
     'dot-notation': 'off',
     'quote-props': ['error', 'as-needed'],
+    // https://eslint.org/docs/latest/rules/prefer-template
+    // Enforce the use of template literals instead of string concatenation: "Hello, " + name + "!" => `Hello, ${name}!`
+    'prefer-template': 'error',
     '@typescript-eslint/no-unsafe-assignment': 'off',
     '@typescript-eslint/no-unused-expressions': 'off',
 };


### PR DESCRIPTION
 instead of string concatenation: `"Hello, " + name + "!"` => \`Hello, ${name}!\`