### PR TITLE
Add MIGRATION Guide

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -29,7 +29,7 @@ The steps are valid for classic javascript and typescritp repositories. If you a
       .prettierignore
       .prettierrc.js
       
-- [ ] create new configuration file 'eslint.config.mjs' for eslint
+- [ ] create new configuration file 'eslint.config.mjs' for eslint in the root directory of the repository
 
       //  
       // ioBroker eslint template configuration file for js and ts files
@@ -65,7 +65,7 @@ The steps are valid for classic javascript and typescritp repositories. If you a
           
       ];
   
-- [ ] create new configuration file 'prettier.config.mjs' for prettier
+- [ ] create new configuration file 'prettier.config.mjs' for prettier in the root directory of the repository
 
       //  
       // iobroker prettier configuration file
@@ -80,9 +80,9 @@ The steps are valid for classic javascript and typescritp repositories. If you a
           //singleQuote: false,
       }
   
-- [ ] check and eventually adapt script definition at pacakge.json
+- [ ] check and eventually adapt script definition at package.json
    
-  Your 'lint' script definitioon at io-package.json should read like this
+  Your 'lint' script definition at package.json should read like this
 
       {
           "scripts": {
@@ -92,7 +92,7 @@ The steps are valid for classic javascript and typescritp repositories. If you a
 
 - [ ] update .npmignore (if still in use)
 
-  If you still use .npmignore and die not yet switch to use `files` section within opackage.json, add the follwoing files to `.npmignore`
+  If you still use .npmignore and not yet switched to use files section within package.json, add the following files to .npmignore
 
       eslint.config.mjs
       prettier.config.mjs

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -12,9 +12,9 @@ The steps are valid for classic javascript and typescritp repositories. If you a
       
 - [ ] remove packages no longer needed
 
-      `npm uninstall eslint-config-prettier`
-      `npm uninstall eslint-plugin-prettier`
-      `npm uninstall prettier`
+      npm uninstall eslint-config-prettier
+      npm uninstall eslint-plugin-prettier
+      npm uninstall prettier
 
 - [ ] update eslint to current version
 
@@ -28,7 +28,9 @@ The steps are valid for classic javascript and typescritp repositories. If you a
 
       .eslintignore
       .eslintrc.json
-
+      .prettierignore
+      .prettierrc.js
+      
 - [ ] create new configuration for eslint
 
         //  

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -31,68 +31,75 @@ The steps are valid for classic javascript and typescritp repositories. If you a
       .prettierignore
       .prettierrc.js
       
-- [ ] create new configuration for eslint
+- [ ] create new configuration file 'eslint.config.mjs' for eslint
 
-        //  
-        // ioBroker eslint template configuration file for js and ts files
-        // Please note that esm or react based modules need additional modules loaded.
-        //  
-        
-        import config from '@iobroker/eslint-config';
+      //  
+      // ioBroker eslint template configuration file for js and ts files
+      // Please note that esm or react based modules need additional modules loaded.
+      //  
       
-        export default [
-            ...config,
-        
-            {
-                // specify files to exclude from linting here
-                ignores: [
-                    '*.test.js', 
-                    'test/**/*.js', 
-                    '*.config.mjs', 
-                    'build', 
-                    'admin/build', 
-                    'admin/words.js'
-                ] 
-            },
-        
-            {
-                // you may disable some 'jsdoc' rules - but using jsdoc is highly recommended
-                // as this improves maintainability. jsdoc warnings will not block buiuld process.
-                rules: {
-                    // 'jsdoc/require-jsdoc': 'off',
-                    // 'jsdoc/require-param': 'off',
-                    // 'jsdoc/require-param-description': 'off',
-                    // 'jsdoc/require-returns-description': 'off',
-                },
-            },
-            
-        ];
+      import config from '@iobroker/eslint-config';
+    
+      export default [
+          ...config,
+      
+          {
+              // specify files to exclude from linting here
+              ignores: [
+                  '*.test.js', 
+                  'test/**/*.js', 
+                  '*.config.mjs', 
+                  'build', 
+                  'admin/build', 
+                  'admin/words.js'
+              ] 
+          },
+      
+          {
+              // you may disable some 'jsdoc' rules - but using jsdoc is highly recommended
+              // as this improves maintainability. jsdoc warnings will not block buiuld process.
+              rules: {
+                  // 'jsdoc/require-jsdoc': 'off',
+                  // 'jsdoc/require-param': 'off',
+                  // 'jsdoc/require-param-description': 'off',
+                  // 'jsdoc/require-returns-description': 'off',
+              },
+          },
+          
+      ];
   
-  - [ ] create new configuration for prettier
+- [ ] create new configuration file 'eslint.config.mjs' for prettier
 
-        //  
-        // iobroker prettier configuration file
-        //  
+      //  
+      // iobroker prettier configuration file
+      //  
 
-        import prettierConfig from '@iobroker/eslint-config/prettier.config.mjs';
-        
-        export default prettierConfig;
+      import prettierConfig from '@iobroker/eslint-config/prettier.config.mjs';
+      
+      export default prettierConfig;
+  
+- [ ] check and eventually adapt script definition at pacakge.json
+   
+  Your 'lint' script definitioon at io-package.json should read like this
 
-  - [ ] check and eventually adapt script definition at pacakge.json
-     
-    Your 'lint' script definitioon at io-package.json should read like this
+      {
+          "scripts": {
+              "lint": "eslint -c eslint.config.mjs ."
+          }
+      }
 
-        {
-            "scripts": {
-                "lint": "eslint -c eslint.config.mjs src"
-            }
-        }
+- [ ] update .npmignore (if still in use)
 
-  - [ ] check functionality by executing
-     
-        npm run lint
+  If you still use .npmignore and die not yet switch to use `files` section within opackage.json, add the follwoing files to `.npmignore`
 
-    Please note that the execution of eslint 9 checks will last longer than previous executions. You might get errors and warnings due to new rules.
-    Feel free to try `npm run lint -- --fix` to perform automatic fixes.
+      eslint.config.mjs
+      prettier.config.mjs
+          
+- [ ] check functionality by executing
+   
+      npm run lint
+
+  Please note that the execution of eslint 9 checks will last longer than previous executions. You might get errors and warnings due to new rules.
+  Feel free to try `npm run lint -- --fix` to perform automatic fixes.
 
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -73,10 +73,15 @@ The steps are valid for classic javascript and typescritp repositories. If you a
       //  
       // iobroker prettier configuration file
       //  
-
+      
       import prettierConfig from '@iobroker/eslint-config/prettier.config.mjs';
       
-      export default prettierConfig;
+      export default {
+          ...prettierConfig,
+      
+          // uncomment next line if you prefer double quotes
+          //singleQuote: false,
+      }
   
 - [ ] check and eventually adapt script definition at pacakge.json
    

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -67,7 +67,7 @@ The steps are valid for classic javascript and typescritp repositories. If you a
           
       ];
   
-- [ ] create new configuration file 'eslint.config.mjs' for prettier
+- [ ] create new configuration file 'prettier.config.mjs' for prettier
 
       //  
       // iobroker prettier configuration file

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -12,13 +12,11 @@ The steps are valid for classic javascript and typescritp repositories. If you a
       
 - [ ] remove packages no longer needed
 
+      npm uninstall eslint
       npm uninstall eslint-config-prettier
       npm uninstall eslint-plugin-prettier
       npm uninstall prettier
 
-- [ ] update eslint to current version
-
-      npm i eslint@latest --save-dev
 
 - [ ] install iobroker standard rules
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,12 +1,12 @@
-# Eslint Migrations Guide
+# ESLint Migrations Guide
 
-## Migration from eslint 8.x.x to 9.x.x
+## Migration from ESLint 8.x.x to 9.x.x
 
-The following steps are recommended when migrating from an existing eslint 8.x.x configuration using .eslint.rc configuration file to an eslint 9.x.x setup using `@iobroker/eslint-config`.
-The steps are valid for classic javascript and typescritp repositories. If you are using esm modules or react the eslint configuration needs to include some more modules. Please see README.md for details.
+The following steps are recommended when migrating from an existing ESLint 8.x.x configuration using `.eslint.rc` configuration file to an ESLint 9.x.x setup using `@iobroker/eslint-config`.
+The steps are valid for vanilla Javascript and TypeScript repositories. If you are using ESM modules or React the ESLint configuration needs to include some more modules. Please see `README.md` for details.
 
 - [ ] Clone your repository to a local workspace
-- [ ] Verify that current (old) eslint configuration is working
+- [ ] Verify that current (old) ESLint configuration is working
 
   Execute `npm run lint` and check for errors. Consider fixing all existing errors before starting the migration.
       
@@ -29,70 +29,66 @@ The steps are valid for classic javascript and typescritp repositories. If you a
       .prettierignore
       .prettierrc.js
       
-- [ ] create new configuration file 'eslint.config.mjs' for eslint in the root directory of the repository
-
-      //  
-      // ioBroker eslint template configuration file for js and ts files
-      // Please note that esm or react based modules need additional modules loaded.
-      //  
-      
-      import config from '@iobroker/eslint-config';
-    
-      export default [
-          ...config,
-      
-          {
-              // specify files to exclude from linting here
-              ignores: [
-                  '*.test.js', 
-                  'test/**/*.js', 
-                  '*.config.mjs', 
-                  'build', 
-                  'admin/build', 
-                  'admin/words.js',
-                  'admin/admin.d.ts',
-                  '**/adapter-config.d.ts'     
-              ] 
-          },
-      
-          {
-              // you may disable some 'jsdoc' warnings - but using jsdoc is highly recommended
-              // as this improves maintainability. jsdoc warnings will not block buiuld process.
-              rules: {
-                  // 'jsdoc/require-jsdoc': 'off',
-              },
-          },
-          
-      ];
+- [ ] create new configuration file `eslint.config.mjs` for ESLint in the root directory of the repository
+  ```js
+  // ioBroker eslint template configuration file for js and ts files
+  // Please note that esm or react based modules need additional modules loaded.
+  import config from '@iobroker/eslint-config';
   
-- [ ] create new configuration file 'prettier.config.mjs' for prettier in the root directory of the repository
-
-      //  
-      // iobroker prettier configuration file
-      //  
+  export default [
+      ...config,
+  
+      {
+          // specify files to exclude from linting here
+          ignores: [
+              '*.test.js', 
+              'test/**/*.js', 
+              '*.config.mjs', 
+              'build', 
+              'admin/build', 
+              'admin/words.js',
+              'admin/admin.d.ts',
+              '**/adapter-config.d.ts'     
+          ] 
+      },
+  
+      {
+          // you may disable some 'jsdoc' warnings - but using jsdoc is highly recommended
+          // as this improves maintainability. jsdoc warnings will not block buiuld process.
+          rules: {
+              // 'jsdoc/require-jsdoc': 'off',
+          },
+      },
       
-      import prettierConfig from '@iobroker/eslint-config/prettier.config.mjs';
-      
-      export default {
-          ...prettierConfig,
-      
-          // uncomment next line if you prefer double quotes
-          //singleQuote: false,
-      }
+  ];
+   ```
+  
+- [ ] create new configuration file 'prettier.config.mjs' for Prettier in the root directory of the repository
+  ```js
+  // iobroker prettier configuration file
+  import prettierConfig from '@iobroker/eslint-config/prettier.config.mjs';
+  
+  export default {
+      ...prettierConfig,
+      // uncomment next line if you prefer double quotes
+      // singleQuote: false,
+  }
+  ```
   
 - [ ] check and eventually adapt script definition at package.json
    
   Your 'lint' script definition at package.json should read like this
-
-      {
-          "scripts": {
-              "lint": "eslint -c eslint.config.mjs ."
-          }
+  ```json
+  {
+      "scripts": {
+          "lint": "eslint -c eslint.config.mjs ."
       }
+  }
+  ```
 
 - [ ] update .npmignore (if still in use)
 
-  If you still use .npmignore and not yet switched to use files section within package.json, add the following files to .npmignore
+  If you still use .npmignore and not yet switched to use files section within package.json, add the following files to `.npmignore`
 
       eslint.config.mjs
       prettier.config.mjs
@@ -101,7 +97,7 @@ The steps are valid for classic javascript and typescritp repositories. If you a
    
       npm run lint
 
-  Please note that the execution of eslint 9 checks will last longer than previous executions. You might get errors and warnings due to new rules.
+  Please note that the execution of ESLint 9 checks will last longer than previous executions. You might get errors and warnings due to new rules.
   Feel free to try `npm run lint -- --fix` to perform automatic fixes.
 
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -51,18 +51,17 @@ The steps are valid for classic javascript and typescritp repositories. If you a
                   '*.config.mjs', 
                   'build', 
                   'admin/build', 
-                  'admin/words.js'
+                  'admin/words.js',
+                  'admin/admin.d.ts',
+                  '**/adapter-config.d.ts'     
               ] 
           },
       
           {
-              // you may disable some 'jsdoc' rules - but using jsdoc is highly recommended
+              // you may disable some 'jsdoc' warnings - but using jsdoc is highly recommended
               // as this improves maintainability. jsdoc warnings will not block buiuld process.
               rules: {
                   // 'jsdoc/require-jsdoc': 'off',
-                  // 'jsdoc/require-param': 'off',
-                  // 'jsdoc/require-param-description': 'off',
-                  // 'jsdoc/require-returns-description': 'off',
               },
           },
           

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -1,0 +1,96 @@
+# Eslint Migrations Guide
+
+## Migration from eslint 8.x.x to 9.x.x
+
+The following steps are recommended when migrating from an existing eslint 8.x.x configuration using .eslint.rc configuration file to an eslint 9.x.x setup using `@iobroker/eslint-config`.
+The steps are valid for classic javascript and typescritp repositories. If you are using esm modules or react the eslint configuration needs to include some more modules. Please see README.md for details.
+
+- [ ] Clone your repository to a local workspace
+- [ ] Verify that current (old) eslint configuration is working
+
+  Execute `npm run lint` and check for errors. Consider fixing all existing errors before starting the migration.
+      
+- [ ] remove packages no longer needed
+
+      `npm uninstall eslint-config-prettier`
+      `npm uninstall eslint-plugin-prettier`
+      `npm uninstall prettier`
+
+- [ ] update eslint to current version
+
+      npm i eslint@latest --save-dev
+
+- [ ] install iobroker standard rules
+
+      npm i @iobroker/eslint-config --save-dev
+
+- [ ] remove old configuration files
+
+      .eslintignore
+      .eslintrc.json
+
+- [ ] create new configuration for eslint
+
+        //  
+        // ioBroker eslint template configuration file for js and ts files
+        // Please note that esm or react based modules need additional modules loaded.
+        //  
+        
+        import config from '@iobroker/eslint-config';
+      
+        export default [
+            ...config,
+        
+            {
+                // specify files to exclude from linting here
+                ignores: [
+                    '*.test.js', 
+                    'test/**/*.js', 
+                    '*.config.mjs', 
+                    'build', 
+                    'admin/build', 
+                    'admin/words.js'
+                ] 
+            },
+        
+            {
+                // you may disable some 'jsdoc' rules - but using jsdoc is highly recommended
+                // as this improves maintainability. jsdoc warnings will not block buiuld process.
+                rules: {
+                    // 'jsdoc/require-jsdoc': 'off',
+                    // 'jsdoc/require-param': 'off',
+                    // 'jsdoc/require-param-description': 'off',
+                    // 'jsdoc/require-returns-description': 'off',
+                },
+            },
+            
+        ];
+  
+  - [ ] create new configuration for prettier
+
+        //  
+        // iobroker prettier configuration file
+        //  
+
+        import prettierConfig from '@iobroker/eslint-config/prettier.config.mjs';
+        
+        export default prettierConfig;
+
+  - [ ] check and eventually adapt script definition at pacakge.json
+     
+    Your 'lint' script definitioon at io-package.json should read like this
+
+        {
+            "scripts": {
+                "lint": "eslint -c eslint.config.mjs src"
+            }
+        }
+
+  - [ ] check functionality by executing
+     
+        npm run lint
+
+    Please note that the execution of eslint 9 checks will last longer than previous executions. You might get errors and warnings due to new rules.
+    Feel free to try `npm run lint -- --fix` to perform automatic fixes.
+
+

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Eslint config for ioBroker projects
+# ESLint config for ioBroker projects
 
 ## Installation
 
@@ -54,6 +54,7 @@ It is suggested to create separate `eslint.config.mjs` files for backend and for
   ### **WORK IN PROGRESS**
 -->
 ### 0.1.7 (2024-11-13)
+
 -   (@foxriver76) Allow `require` imports for `.js` files
 
 ### 0.1.6 (2024-09-16)


### PR DESCRIPTION
This document should describe the necessary steps for existing repositories to migrate from classic eslint 8.x.x to eslint 9.x.x using @iobroker/eslint-config.