### PR TITLE
modify no-unused-vars for *.js

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ It is suggested to create separate `eslint.config.mjs` files for backend and for
   Placeholder for the next version (at the beginning of the line):
   ### **WORK IN PROGRESS**
 -->
+
+### **WORK IN PROGRESS**
+-   (@mcm1957/@foxriver76) allow unused args with `_` prefix in JavaScript too
+
 ### 0.1.7 (2024-11-13)
 -   (@foxriver76) Allow `require` imports for `.js` files
 

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -48,8 +48,21 @@ const generalRules = {
     '@typescript-eslint/no-unused-expressions': 'off',
 };
 
+/** Rules for js and ts files */
+const jsAndTsRules = {
+    '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+            ignoreRestSiblings: true,
+            argsIgnorePattern: '^_',
+            caughtErrors: 'all',
+        },
+    ],
+}
+
 /** General TypeScript rules */
 const tsRules = {
+    ...jsAndTsRules,
     '@typescript-eslint/no-parameter-properties': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
     '@typescript-eslint/unbound-method': 'off',
@@ -59,14 +72,6 @@ const tsRules = {
             functions: false,
             typedefs: false,
             classes: false,
-        },
-    ],
-    '@typescript-eslint/no-unused-vars': [
-        'error',
-        {
-            ignoreRestSiblings: true,
-            argsIgnorePattern: '^_',
-            caughtErrors: 'all',
         },
     ],
     '@typescript-eslint/no-object-literal-type-assertion': 'off',
@@ -138,17 +143,14 @@ const tsRules = {
 };
 
 /** Separate config for .js files which is applied internally */
-const plainJsConfig = tseslint.configs.disableTypeChecked
-plainJsConfig.rules['@typescript-eslint/no-require-imports'] = 'off';
-plainJsConfig.rules['@typescript-eslint/no-unused-vars': [
-        'error',
-        {
-            ignoreRestSiblings: true,
-            argsIgnorePattern: '^_',
-            caughtErrors: 'all',
-        },
-    ],
-];
+const plainJsConfig = {
+    ...tseslint.configs.disableTypeChecked ,
+    rules: {
+        ...tseslint.configs.disableTypeChecked.rules,
+        ...jsAndTsRules,
+        '@typescript-eslint/no-require-imports': 'off',
+    }
+}
 
 /** @type {import("eslint").Linter.FlatConfig[]} */
 export default tseslint.config(

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -144,7 +144,7 @@ const tsRules = {
 
 /** Separate config for .js files which is applied internally */
 const plainJsConfig = {
-    ...tseslint.configs.disableTypeChecked ,
+    ...tseslint.configs.disableTypeChecked,
     rules: {
         ...tseslint.configs.disableTypeChecked.rules,
         ...jsAndTsRules,

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -140,6 +140,15 @@ const tsRules = {
 /** Separate config for .js files which is applied internally */
 const plainJsConfig = tseslint.configs.disableTypeChecked
 plainJsConfig.rules['@typescript-eslint/no-require-imports'] = 'off';
+plainJsConfig.rules['@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+            ignoreRestSiblings: true,
+            argsIgnorePattern: '^_',
+            caughtErrors: 'all',
+        },
+    ],
+];
 
 /** @type {import("eslint").Linter.FlatConfig[]} */
 export default tseslint.config(


### PR DESCRIPTION
This PR tries to modify no-unused-vars like it is already done for ts files.

BUT maybe it would be better to restructure the complete pur js config into some const jsRules = { ... } like it is done for tsRules.
Not sure how to structure this. So feel free to simply close this PR and change code yourself.

Related to #20