### PR TITLE
update ignore list recommandation at MIGRATION.md

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -41,6 +41,8 @@ The steps are valid for vanilla Javascript and TypeScript repositories. If you a
       {
           // specify files to exclude from linting here
           ignores: [
+              '.dev-server/',
+              '.vscode/',
               '*.test.js', 
               'test/**/*.js', 
               '*.config.mjs', 


### PR DESCRIPTION
Please merge and update MIGRATION.md as missing to exclude  .dev-server causes problems if dev-server is installed locally.
(npm run lint seems to loop while it is checking 10000 modules from dev-server installation

@foxriver76 
@GermanBluefox 

P.S. I created a PR for integration as default , but this PR must be checked carefully first