### PR TITLE
Update eslint.config.mjs

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -136,6 +136,9 @@ const tsRules = {
     '@typescript-eslint/no-unsafe-declaration-merging': 'off',
     '@typescript-eslint/consistent-type-imports': 'error',
     '@typescript-eslint/consistent-type-exports': 'error',
+    'require-await': 'off',
+    '@typescript-eslint/require-await': 'error',
+
 };
 
 /** Separate config for .js files which is applied internally */


### PR DESCRIPTION
```
            "require-await": "off",
            "@typescript-eslint/require-await": "error",
```
Bei TS hinzugefügt.

In meinem Fall werden ohne dieses Modifikation nur await aufrufe in der gleichen Datei gewertet, ist in der selben Datei kein Aufruf gibts einen lint Fehler.

Erläuterung: https://typescript-eslint.io/rules/require-await/

EDIT: Quark es werden unnötige async angezeigt